### PR TITLE
Handle more complicated gRPC setups

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -219,8 +219,8 @@ export class Client {
         resolve(result);
       });
 
-      const request = new ServerReflectionRequest();
       symbolsToFetch.forEach(symbol => {
+        const request = new ServerReflectionRequest();
         grpcCall.write(request.setFileByFilename(symbol));
       });
 


### PR DESCRIPTION
https://github.com/postmanlabs/postman-app-support/issues/11625 details how more complicated proto file setups result in "no such Type or Enum" errors. https://github.com/postmanlabs/grpc-reflection-js/commit/077396c802c388d0a20ab5f019adac356856898f moves `new ServerReflectionRequest()` per symbol. This seems to be what resolved the issue.